### PR TITLE
[InternalApi] ThreadSafeUpdate fix

### DIFF
--- a/PetProject/CurrencyApi/InternalApi.Tests/CachedCurrencyApiTests.cs
+++ b/PetProject/CurrencyApi/InternalApi.Tests/CachedCurrencyApiTests.cs
@@ -22,6 +22,7 @@ public class CachedCurrencyApiTests : IDisposable
     private readonly Mock<IOptionsMonitor<CurrencyCacheSettings>> _cacheOptionsMock = new();
     private readonly RenewalDatesDictionary _lockerDictionary = new();
     private readonly AppDbContext _dbContext;
+    private readonly TestAppDbContextDatabaseFixture _fixture;
 
     private readonly CurrencyCacheSettings _cacheSettingsMock = new()
     {
@@ -33,6 +34,8 @@ public class CachedCurrencyApiTests : IDisposable
     public CachedCurrencyApiTests(TestAppDbContextDatabaseFixture fixture)
     {
         Fixture = fixture;
+        _fixture = fixture;
+
         _dbContext = fixture.CreateContext();
         _cacheOptionsMock.Setup(o => o.CurrentValue).Returns(_cacheSettingsMock);
         object? expectedOut = new();
@@ -52,9 +55,11 @@ public class CachedCurrencyApiTests : IDisposable
     public async Task GetCurrentCurrencyAsync_ReturnCurrencyFromInMemoryCache()
     {
         // Arrange
+        var ct = CancellationToken.None;
+        
         var currencyType = CurrencyType.USD;
         decimal value = 100;
-        var ct = CancellationToken.None;
+        
         var entity = new Currency { Id = 0, Code = currencyType, Value = value, RateDate = DateTime.Now };
         object expectedOut = entity;
         _memoryCacheMock.Setup(c => c.TryGetValue(It.IsAny<object>(), out expectedOut!)).Returns(true);
@@ -73,9 +78,11 @@ public class CachedCurrencyApiTests : IDisposable
     public async Task GetCurrentCurrencyAsync_ReturnCurrencyFromDbCache()
     {
         // Arrange
+        var ct = CancellationToken.None;
+        
         var currencyType = CurrencyType.USD;
         decimal value = 100;
-        var ct = CancellationToken.None;
+        
         var entity = new Currency { Id = 0, Code = currencyType, Value = value, RateDate = DateTime.Now };
         _dbContext.Currencies.Add(entity);
         await _dbContext.SaveChangesAsync(ct);
@@ -94,18 +101,15 @@ public class CachedCurrencyApiTests : IDisposable
     public async Task GetCurrentCurrencyAsync_ReturnNewCurrencyFromApi_WhenCurrencyNotFoundInCache()
     {
         // Arrange
+        var ct = CancellationToken.None;
+        
         var currencyType = CurrencyType.USD;
         decimal value = 100;
         var date = DateTime.Now.AddHours(-1);
-        var ct = CancellationToken.None;
+        
         var entity = new Currency { Code = currencyType, Value = value, RateDate = date };
-        var apiResponse = new RootCurrencyApiDto
-        {
-            Meta = new MetaCurrencyApiDto { LastUpdatedAt = DateTime.Now },
-            Data = new Dictionary<string, CurrencyApiDto>()
-        };
-        apiResponse.Data.Add(currencyType.ToString(),
-            new CurrencyApiDto { Code = currencyType.ToString(), Value = value });
+        
+        var apiResponse = RootCurrencyApiDtoFactory(DateTime.Now, currencyType, value);
         _externalApiMock
             .Setup(api => api.GetAllCurrentCurrenciesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => apiResponse);
@@ -114,6 +118,7 @@ public class CachedCurrencyApiTests : IDisposable
         await _dbContext.Database.BeginTransactionAsync(ct);
         var actual = await _sut.GetCurrentCurrencyAsync(currencyType, ct);
         _dbContext.ChangeTracker.Clear();
+        
         // Assert
         _externalApiMock.Verify(
             api => api.GetAllCurrentCurrenciesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -125,10 +130,12 @@ public class CachedCurrencyApiTests : IDisposable
     public async Task GetCurrencyOnDateAsync_ReturnCurrencyFromInMemoryCache()
     {
         // Arrange
+        var ct = CancellationToken.None;
+        
         var currencyType = CurrencyType.USD;
         decimal value = 100;
         var date = DateTime.UtcNow.AddDays(-100);
-        var ct = CancellationToken.None;
+        
         var entity = new Currency { Id = 0, Code = currencyType, Value = value, RateDate = date };
         object expectedOut = entity;
         _memoryCacheMock.Setup(c => c.TryGetValue(It.IsAny<object>(), out expectedOut!)).Returns(true);
@@ -148,10 +155,12 @@ public class CachedCurrencyApiTests : IDisposable
     public async Task GetCurrencyOnDateAsync_ReturnCurrencyFromDbCache()
     {
         // Arrange
+        var ct = CancellationToken.None;
+        
         var currencyType = CurrencyType.USD;
         decimal value = 100;
         var date = DateTime.UtcNow.AddDays(-100);
-        var ct = CancellationToken.None;
+        
         var entity = new Currency { Id = 0, Code = currencyType, Value = value, RateDate = date };
         _dbContext.Currencies.Add(entity);
         await _dbContext.SaveChangesAsync(ct);
@@ -170,17 +179,16 @@ public class CachedCurrencyApiTests : IDisposable
     public async Task GetCurrencyOnDateAsync_ReturnNewCurrencyFromApi_WhenCurrencyNotFoundInCache()
     {
         // Arrange
+        var ct = CancellationToken.None;
+        
+        
         var currencyType = CurrencyType.USD;
         decimal value = 100;
         var date = DateTime.Now.AddHours(-1).AddDays(-100);
-        var ct = CancellationToken.None;
+        
         var entity = new Currency { Code = currencyType, Value = value, RateDate = date };
-        var apiResponse = new RootCurrencyApiDto
-        {
-            Meta = new MetaCurrencyApiDto { LastUpdatedAt = date }, Data = new Dictionary<string, CurrencyApiDto>()
-        };
-        apiResponse.Data.Add(currencyType.ToString(),
-            new CurrencyApiDto { Code = currencyType.ToString(), Value = value });
+        
+        var apiResponse = RootCurrencyApiDtoFactory(date, currencyType, value);
         _externalApiMock
             .Setup(api =>
                 api.GetAllCurrenciesOnDateAsync(It.IsAny<string>(), It.IsAny<DateOnly>(),
@@ -190,11 +198,102 @@ public class CachedCurrencyApiTests : IDisposable
         await _dbContext.Database.BeginTransactionAsync(ct);
         var actual = await _sut.GetCurrencyOnDateAsync(currencyType, DateOnly.FromDateTime(date), ct);
         _dbContext.ChangeTracker.Clear();
+        
         // Assert
         Assert.Equal(entity.Code, actual.Code);
         Assert.Equal(entity.Value, actual.Value);
         _externalApiMock.Verify(
             api => api.GetAllCurrenciesOnDateAsync(It.IsAny<string>(), It.IsAny<DateOnly>(),
                 It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCurrentCurrencyAsync_ThreadSafe()
+    {
+        // Arrange
+        var cancellationToken = CancellationToken.None;
+        
+        CachedCurrencyApi sut;
+        var lockerDictionary = new RenewalDatesDictionary();
+
+        var currencyType = CurrencyType.USD;
+        var targetDate = DateTimeOffset.UtcNow;
+        var apiDto = RootCurrencyApiDtoFactory(targetDate.Date, currencyType, 10);
+        
+        _externalApiMock.Setup(a =>
+                a.GetAllCurrentCurrenciesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(() => Task.FromResult(apiDto));
+
+        // Act
+        //Todo: найти способ обеспечить изоляцию - тесты падают из-за неуникальных значений.
+        
+        var tasks = Enumerable.Range(1, 100).Select(async _ =>
+        {
+            await using var dbContext = _fixture.CreateContext();
+            sut = new CachedCurrencyApi(_loggerMock.Object, _externalApiMock.Object, _cacheOptionsMock.Object,
+                dbContext, lockerDictionary, _memoryCacheMock.Object);
+
+            await sut.GetCurrentCurrencyAsync(currencyType, cancellationToken);
+        });
+        await Task.WhenAll(tasks);
+        
+        //Assert
+        _externalApiMock.Verify(
+            a => a.GetAllCurrentCurrenciesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.True(_lockerDictionary.RenewalDatesLockDictionary.IsEmpty);
+    }
+
+    [Fact]
+    public async Task GetCurrencyOnDateAsync_ThreadSafe()
+    {
+        // Arrange
+        var cancellationToken = CancellationToken.None;
+
+        CachedCurrencyApi sut;
+        var lockerDictionary = new RenewalDatesDictionary();
+
+        var currencyType = CurrencyType.USD;
+        var targetDate = DateTime.Now.AddHours(-1).AddDays(-20);
+        
+        var apiResponse = RootCurrencyApiDtoFactory(targetDate, currencyType,10);
+        _externalApiMock
+            .Setup(api =>
+                api.GetAllCurrenciesOnDateAsync(It.IsAny<string>(), It.IsAny<DateOnly>(),
+                    It.IsAny<CancellationToken>())).ReturnsAsync(() => apiResponse);
+
+        // Act
+        //Todo: найти способ обеспечить изоляцию - тесты падают из-за неуникальных значений.
+        
+        var tasks = Enumerable.Range(1, 100).Select(async _ =>
+        {
+            await using var dbContext = _fixture.CreateContext();
+            sut = new CachedCurrencyApi(_loggerMock.Object, _externalApiMock.Object, _cacheOptionsMock.Object,
+                dbContext, lockerDictionary, _memoryCacheMock.Object);
+
+            await sut.GetCurrencyOnDateAsync(currencyType: currencyType,
+                date: DateOnly.FromDateTime(targetDate), cancellationToken);
+        });
+        await Task.WhenAll(tasks);
+        
+        //Assert
+        _externalApiMock.Verify(a => a.GetAllCurrenciesOnDateAsync(
+                It.IsAny<string>(),
+                It.IsAny<DateOnly>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.True(_lockerDictionary.RenewalDatesLockDictionary.IsEmpty);
+    }
+
+    private static RootCurrencyApiDto RootCurrencyApiDtoFactory(DateTime date, CurrencyType currencyType, decimal value)
+    {
+        return new RootCurrencyApiDto
+        {
+            Meta = new MetaCurrencyApiDto { LastUpdatedAt = date },
+            Data = new Dictionary<string, CurrencyApiDto>
+            {
+                { currencyType.ToString(), new CurrencyApiDto { Code = currencyType.ToString(), Value = value } }
+            }
+        };
     }
 }

--- a/PetProject/CurrencyApi/InternalApi/InternalApi.Api/Services/Cache/CachedCurrencyApi.cs
+++ b/PetProject/CurrencyApi/InternalApi/InternalApi.Api/Services/Cache/CachedCurrencyApi.cs
@@ -186,8 +186,7 @@ public class CachedCurrencyApi : ICachedCurrencyApi
         /*
          * Я попытался создать потокобезопасное обновление кеша: только один поток должен пытаться получить кеш от удаленного API потому,
          * что токены - конечный ресурс и следует их оптимизировать как можно сильнее.
-         *
-         * Я не успел довести до ума: не реализовано очищение словаря. В тестах вроде бы ко внешнему API обращается один раз.
+         * Мне не нравится это решение. Но оно, кажется, работает.
          */
 
         // Дата, на которую обновляется кеш
@@ -227,7 +226,13 @@ public class CachedCurrencyApi : ICachedCurrencyApi
             finally
             {
                 updatingMutex.Release();
-                _cacheUpdateLock.RenewalDatesLockDictionary.TryRemove(updatingDate, out _);
+                
+                //Если семафор никем не ожидается - очистить.
+                if (updatingMutex.CurrentCount == 1)
+                {
+                    _cacheUpdateLock.RenewalDatesLockDictionary.TryRemove(updatingDate, out _);
+                }
+                
             }
         }
 


### PR DESCRIPTION
Добавлена проверка перед удалением семафора из глобальной коллекции: если никто не ожидает.
Написаны тесты для проверки потокобезопасности методов кеша. Предыдущие тесты internal методов сервиса кеша (которые должны быть private) временно сохранены.
Чуть-чуть улучшил читабельность тестов.
